### PR TITLE
Component Updates

### DIFF
--- a/examples/component_test/main.nim
+++ b/examples/component_test/main.nim
@@ -9,12 +9,16 @@ import ../../src/Eclipse
 var game: Game
 
 
-proc runOnce(obj: var GameObjectInstance, cmp: Component) =
+proc runOnce(objRef: var RootRef, cmp: Component) =
+  var obj = GameObjectInstance(objRef)
   echo "I run once when the game object is created"
   echo fmt"Object ID: {obj.uid}"
 
 # arrow keys movement
-proc movementScript(obj: var GameObjectInstance, cmp: Component) =
+proc movementScript(objRef: var RootRef, cmp: Component) =
+  # cast
+  var obj = GameObjectInstance(objRef)
+
   if game.keyIsHeld(Key_Up):
     obj.position.y -= 10
 
@@ -29,7 +33,10 @@ proc movementScript(obj: var GameObjectInstance, cmp: Component) =
 
 # scroll through colors in a rainbow
 let cycleSpeed: uint8 = 1
-proc colorScript(obj: var GameObjectInstance, cmp: Component) =
+proc colorScript(objRef: var RootRef, cmp: Component) =
+  # cast
+  var obj = GameObjectInstance(objRef)
+
   randomize()
   let oldColor = obj.getAttributeValue("color", DrawColor)
   var r = oldColor.r

--- a/examples/component_test/main.nim
+++ b/examples/component_test/main.nim
@@ -9,11 +9,15 @@ import ../../src/Eclipse
 var game: Game
 
 
-proc runOnce(objRef: var RootRef, cmp: Component) =
-  var obj = GameObjectInstance(objRef)
+
+## via templates
+var runOnceCmp = makeComponent(GameObjectInstance, "runOnce", ctkStart):
   echo "I run once when the game object is created"
+  echo obj
   echo fmt"Object ID: {obj.uid}"
 
+
+## or via proc
 # arrow keys movement
 proc movementScript(objRef: var RootRef, cmp: Component) =
   # cast
@@ -114,7 +118,7 @@ proc main() =
   objBase.addAttribute("color", drawcolor(255, 255, 255, 255))
   objBase.addAttribute("color_state", 0)
   
-  objBase.addComponent(runOnce, nil)
+  objBase.addComponent(runOnceCmp)
   objBase.addComponent(nil, movementScript)
   objBase.addComponent(nil, colorScript)
 

--- a/examples/texture_test/main.nim
+++ b/examples/texture_test/main.nim
@@ -14,6 +14,47 @@ var
   fps: int
   flipped: bool = false
 
+proc playerUpdateCmp*(objRef: var RootRef, cmp: Component) =
+  var sobj = SpriteObjectInstance(objRef)
+
+  let speed = 200.0 * game.getDt()
+  
+  # Move
+  if game.keyIsHeld(Key_Left):
+    sobj.position.x -= speed
+    sobj.flip = FlipHorizontal.int32
+    flipped = true
+  
+  if game.keyIsHeld(Key_Right):
+    sobj.position.x += speed
+    sobj.flip = FlipNone.int32
+    flipped = false
+  
+  if game.keyIsHeld(Key_Up):
+    sobj.position.y -= speed
+  
+  if game.keyIsHeld(Key_Down):
+    sobj.position.y += speed
+  
+  # Rotate
+  if game.keyIsHeld(Key_A):
+    angle -= 90.0 * game.getDt()
+    angle = max(angle, 0.0)
+  
+  if game.keyIsHeld(Key_D):
+    angle += 90.0 * game.getDt()
+    angle = min(angle, 360.0)
+  sobj.rotation = angle
+  
+  # Pulse
+  if game.keyIsHeld(Key_Space):
+    let pulse = (sin(getTicks().float / 200.0) + 1.0) / 2.0
+    var color = sobj.spriteObject.texture.color
+    color.r = uint8(255.0 * pulse)
+    color.g = uint8(255.0 * pulse)
+    color.b = uint8(255.0 * pulse)
+    sobj.spriteObject.texture.setTextureColor(color)
+
 proc initGame*(win: EclipseWindow, game: var Game) =
   mainFont = game.loadFont("main", "sans.ttf", 16)
   game.setDefaultFont("main")
@@ -24,6 +65,9 @@ proc initGame*(win: EclipseWindow, game: var Game) =
     
   # Create SpriteObject; variant of GameObject with a texture attached
   var playerObj = newSpriteObject("player")
+  # sprite specific component
+  var spriteComponent = newSpriteComponent(nil, playerUpdateCmp)
+  playerObj.addComponent(spriteComponent)
   playerObj.setTexture(playerTexture)
   
   playerObj.setPosition(
@@ -39,51 +83,10 @@ proc updateGame*(win: EclipseWindow, game: var Game) =
   if game.keyIsReleased(Key_Escape):
     game.stop()
   
-  let speed = 200.0 * game.getDt()
-  
-  # Move
-  if game.keyIsHeld(Key_Left):
-    playerSprite.position.x -= speed
-    playerSprite.flip = FlipHorizontal.int32
-    flipped = true
-  
-  if game.keyIsHeld(Key_Right):
-    playerSprite.position.x += speed
-    playerSprite.flip = FlipNone.int32
-    flipped = false
-  
-  if game.keyIsHeld(Key_Up):
-    playerSprite.position.y -= speed
-  
-  if game.keyIsHeld(Key_Down):
-    playerSprite.position.y += speed
-  
-  # Rotate
-  if game.keyIsHeld(Key_A):
-    angle -= 90.0 * game.getDt()
-    angle = max(angle, 0.0)
-  
-  if game.keyIsHeld(Key_D):
-    angle += 90.0 * game.getDt()
-    angle = min(angle, 360.0)
-  playerSprite.rotation = angle
-  
-  # Pulse
-  if game.keyIsHeld(Key_Space):
-    let pulse = (sin(getTicks().float / 200.0) + 1.0) / 2.0
-    var color = playerSprite.spriteObject.texture.color
-    color.r = uint8(255.0 * pulse)
-    color.g = uint8(255.0 * pulse)
-    color.b = uint8(255.0 * pulse)
-    playerSprite.spriteObject.texture.setTextureColor(color)
-  
   fps = int(game.getFPS())
 
 let textColor = drawcolor(0, 0, 0, 255)
 proc drawGame*(win: EclipseWindow, game: var Game) =
-  # may flip around or change
-  game.currentScene.draw(win)
-
   # info
   win.renderText("FPS: " & $fps, 10, 10, mainFont, textColor)
   win.renderText("Arrow Keys: Move", 10, 30, mainFont, textColor)

--- a/src/Eclipse/game.nim
+++ b/src/Eclipse/game.nim
@@ -276,6 +276,7 @@ proc run*(game: var Game, window: EclipseWindow) =
 
     window.clearScreen()
     window.draw(game)
+    game.currentScene.draw(window)
     game.drawProc(window, game)
     window.presentScreen()
 

--- a/src/Eclipse/scene.nim
+++ b/src/Eclipse/scene.nim
@@ -29,8 +29,12 @@ proc update*(scene: var Scene) =
   for i in 0 ..< scene.objects.len:
     var obj = scene.objects[i]
     if obj.enabled:
-      obj.update()
-      scene.objects[i] = obj # replicate 
+      if obj of SpriteObjectInstance:
+        update(SpriteObjectInstance(obj))
+        scene.objects[i] = obj
+      else:
+        obj.update()
+        scene.objects[i] = obj # replicate 
 
 proc draw*(scene: Scene, ew: EclipseWindow) =
   for obj in scene.objects:


### PR DESCRIPTION
Adds support for components on SpriteObject (and future object types)

- Comes with a minor drawback; componentprocs have to be refactored and they have to manually cast the object at the start,
but other than that it works effectively and can be extended to other future objects

- may add more backwards compatible functions/template for returning as close to old functionality as possible (if possible)

- in addition: the current game scene is now drawn automatically when using callbacks

Adds templates for component creation

- auto casts for you, providing the "obj" variable for use and the other variables with regular components
  - may cause your linter to complain; but compiles fine and is fine with `nim check`

- can be of update or start kind (defined by parameter)